### PR TITLE
Implemented JSON asynchronous deserialization 

### DIFF
--- a/R6Sharp/ApiHelper.cs
+++ b/R6Sharp/ApiHelper.cs
@@ -10,13 +10,13 @@ namespace R6Sharp
 {
     internal static class ApiHelper
     {
-        internal static async Task<string> GetDataAsync(string url, Guid player, IEnumerable<KeyValuePair<string, string>> queries, Session session)
+        internal static async Task<Stream> GetDataAsync(string url, Guid player, IEnumerable<KeyValuePair<string, string>> queries, Session session)
         {
             url = string.Format(url, player.ToString());
             return await GetDataAsync(url, queries, session).ConfigureAwait(false);
         }
 
-        internal static async Task<string> GetDataAsync(string url, Platform? platform, IEnumerable<KeyValuePair<string, string>> queries, Session session)
+        internal static async Task<Stream> GetDataAsync(string url, Platform? platform, IEnumerable<KeyValuePair<string, string>> queries, Session session)
         {
             if (platform != null)
             {
@@ -34,7 +34,7 @@ namespace R6Sharp
             return await GetDataAsync(url, queries, session).ConfigureAwait(false);
         }
 
-        private static async Task<string> GetDataAsync(string url, IEnumerable<KeyValuePair<string, string>> queries, Session session)
+        private static async Task<Stream> GetDataAsync(string url, IEnumerable<KeyValuePair<string, string>> queries, Session session)
         {
             if (queries != null)
             {
@@ -60,7 +60,7 @@ namespace R6Sharp
             return await BuildRequestAsync(uri, headerValuePairs.ToArray(), null, true).ConfigureAwait(false);
         }
 
-        internal static async Task<string> BuildRequestAsync(Uri uri, KeyValuePair<string, string>[] additionalHeaderValues, byte[] data, bool get)
+        internal static async Task<Stream> BuildRequestAsync(Uri uri, KeyValuePair<string, string>[] additionalHeaderValues, byte[] data, bool get)
         {
             // Build a web request to endpoint
             var request = WebRequest.CreateHttp(uri);
@@ -89,16 +89,12 @@ namespace R6Sharp
                 }
             }
 
-            string result;
             // Get result from Ubisoft and grab the json
             using (var response = (HttpWebResponse)request.GetResponse())
             using (var stream = response.GetResponseStream())
-            using (var reader = new StreamReader(stream))
             {
-                result = await reader.ReadToEndAsync().ConfigureAwait(false);
+                return stream;
             }
-
-            return result;
         }
 
         internal static string DeriveGamemodeFlags(Gamemode gamemode)

--- a/R6Sharp/Endpoint/PlayerEndpoint.cs
+++ b/R6Sharp/Endpoint/PlayerEndpoint.cs
@@ -146,7 +146,7 @@ namespace R6Sharp.Endpoint
 
             var session = await _sessionHandler.GetCurrentSessionAsync().ConfigureAwait(false);
             var results = await ApiHelper.GetDataAsync(Endpoints.UbiServices.Players, platform, queries, session).ConfigureAwait(false);
-            var deserialised = JsonSerializer.Deserialize<BoardInfoFetch>(results);
+            var deserialised = await JsonSerializer.DeserializeAsync<BoardInfoFetch>(results).ConfigureAwait(false);
             return deserialised.Players;
         }
     }

--- a/R6Sharp/Endpoint/PlayerEndpoint.cs
+++ b/R6Sharp/Endpoint/PlayerEndpoint.cs
@@ -145,7 +145,7 @@ namespace R6Sharp.Endpoint
             };
 
             var session = await _sessionHandler.GetCurrentSessionAsync().ConfigureAwait(false);
-            var results = await ApiHelper.GetDataAsync(Endpoints.UbiServices.Players, platform, queries, session).ConfigureAwait(false);
+            using var results = await ApiHelper.GetDataAsync(Endpoints.UbiServices.Players, platform, queries, session).ConfigureAwait(false);
             var deserialised = await JsonSerializer.DeserializeAsync<BoardInfoFetch>(results).ConfigureAwait(false);
             return deserialised.Players;
         }

--- a/R6Sharp/Endpoint/PlayerProgressionEndpoint.cs
+++ b/R6Sharp/Endpoint/PlayerProgressionEndpoint.cs
@@ -35,7 +35,7 @@ namespace R6Sharp.Endpoint
             };
 
             var session = await _sessionHandler.GetCurrentSessionAsync().ConfigureAwait(false);
-            var results = await ApiHelper.GetDataAsync(Endpoints.UbiServices.Progressions, platform, queries, session).ConfigureAwait(false);
+            using var results = await ApiHelper.GetDataAsync(Endpoints.UbiServices.Progressions, platform, queries, session).ConfigureAwait(false);
             var deserialised = await JsonSerializer.DeserializeAsync<PlayerProgressionFetch>(results).ConfigureAwait(false);
             foreach (var result in deserialised.PlayerProgressions)
             {

--- a/R6Sharp/Endpoint/PlayerProgressionEndpoint.cs
+++ b/R6Sharp/Endpoint/PlayerProgressionEndpoint.cs
@@ -36,7 +36,7 @@ namespace R6Sharp.Endpoint
 
             var session = await _sessionHandler.GetCurrentSessionAsync().ConfigureAwait(false);
             var results = await ApiHelper.GetDataAsync(Endpoints.UbiServices.Progressions, platform, queries, session).ConfigureAwait(false);
-            var deserialised = JsonSerializer.Deserialize<PlayerProgressionFetch>(results);
+            var deserialised = await JsonSerializer.DeserializeAsync<PlayerProgressionFetch>(results).ConfigureAwait(false);
             foreach (var result in deserialised.PlayerProgressions)
             {
                 // Attach link to player profile icon url

--- a/R6Sharp/Endpoint/PlayersSkillRecordsEndpoint.cs
+++ b/R6Sharp/Endpoint/PlayersSkillRecordsEndpoint.cs
@@ -27,7 +27,7 @@ namespace R6Sharp.Endpoint
 
             var session = await _sessionHandler.GetCurrentSessionAsync().ConfigureAwait(false);
             var results = await ApiHelper.GetDataAsync(Endpoints.UbiServices.PlayerSkillRecords, platform, queries, session).ConfigureAwait(false);
-            var deserialised = JsonSerializer.Deserialize<PlayersSkillRecords>(results);
+            var deserialised = await JsonSerializer.DeserializeAsync<PlayersSkillRecords>(results).ConfigureAwait(false);
             return deserialised;
         }
 

--- a/R6Sharp/Endpoint/PlayersSkillRecordsEndpoint.cs
+++ b/R6Sharp/Endpoint/PlayersSkillRecordsEndpoint.cs
@@ -26,7 +26,7 @@ namespace R6Sharp.Endpoint
             };
 
             var session = await _sessionHandler.GetCurrentSessionAsync().ConfigureAwait(false);
-            var results = await ApiHelper.GetDataAsync(Endpoints.UbiServices.PlayerSkillRecords, platform, queries, session).ConfigureAwait(false);
+            using var results = await ApiHelper.GetDataAsync(Endpoints.UbiServices.PlayerSkillRecords, platform, queries, session).ConfigureAwait(false);
             var deserialised = await JsonSerializer.DeserializeAsync<PlayersSkillRecords>(results).ConfigureAwait(false);
             return deserialised;
         }

--- a/R6Sharp/Endpoint/ProfileEndpoint.cs
+++ b/R6Sharp/Endpoint/ProfileEndpoint.cs
@@ -64,7 +64,7 @@ namespace R6Sharp.Endpoint
 
             var session = await _sessionHandler.GetCurrentSessionAsync().ConfigureAwait(false);
             var results = await ApiHelper.GetDataAsync(Endpoints.UbiServices.Search, null, queries, session).ConfigureAwait(false);
-            var deserialised = JsonSerializer.Deserialize<ProfileSearch>(results);
+            var deserialised = await JsonSerializer.DeserializeAsync<ProfileSearch>(results).ConfigureAwait(false);
             return deserialised.Profiles;
         }
     }

--- a/R6Sharp/Endpoint/ProfileEndpoint.cs
+++ b/R6Sharp/Endpoint/ProfileEndpoint.cs
@@ -63,7 +63,7 @@ namespace R6Sharp.Endpoint
             queries.Add(new KeyValuePair<string, string>(queryKey, queryValue));
 
             var session = await _sessionHandler.GetCurrentSessionAsync().ConfigureAwait(false);
-            var results = await ApiHelper.GetDataAsync(Endpoints.UbiServices.Search, null, queries, session).ConfigureAwait(false);
+            using var results = await ApiHelper.GetDataAsync(Endpoints.UbiServices.Search, null, queries, session).ConfigureAwait(false);
             var deserialised = await JsonSerializer.DeserializeAsync<ProfileSearch>(results).ConfigureAwait(false);
             return deserialised.Profiles;
         }

--- a/R6Sharp/Endpoint/SessionEndpoint.cs
+++ b/R6Sharp/Endpoint/SessionEndpoint.cs
@@ -125,7 +125,7 @@ namespace R6Sharp.Endpoint
             // Get result from endpoint
             var endpoint = new Uri(Endpoints.UbiServices.Sessions);
             var response = await ApiHelper.BuildRequestAsync(endpoint, headervaluepairs, data, false).ConfigureAwait(false);
-            return JsonSerializer.Deserialize<Session>(response);
+            return await JsonSerializer.DeserializeAsync<Session>(response).ConfigureAwait(false);
         }
     }
 }

--- a/R6Sharp/Endpoint/SessionEndpoint.cs
+++ b/R6Sharp/Endpoint/SessionEndpoint.cs
@@ -124,8 +124,9 @@ namespace R6Sharp.Endpoint
 
             // Get result from endpoint
             var endpoint = new Uri(Endpoints.UbiServices.Sessions);
-            using var response = await ApiHelper.BuildRequestAsync(endpoint, headervaluepairs, data, false).ConfigureAwait(false);
-            return await JsonSerializer.DeserializeAsync<Session>(response).ConfigureAwait(false);
+            var response = await ApiHelper.BuildRequestAsync(endpoint, headervaluepairs, data, false).ConfigureAwait(false);
+            using var stream = response.Item2;
+            return await JsonSerializer.DeserializeAsync<Session>(stream).ConfigureAwait(false);
         }
     }
 }

--- a/R6Sharp/Exceptions/ApiBadResponseException.cs
+++ b/R6Sharp/Exceptions/ApiBadResponseException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace R6Sharp.Exceptions
+{
+    [Serializable]
+    internal class ApiBadResponseException : Exception
+    {
+        public ApiBadResponseException()
+        {
+        }
+
+        public ApiBadResponseException(string message) : base(message)
+        {
+        }
+
+        public ApiBadResponseException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected ApiBadResponseException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/R6Sharp/Parser.cs
+++ b/R6Sharp/Parser.cs
@@ -149,7 +149,7 @@ namespace R6Sharp
                 }
                 catch (FormatException)
                 {
-                    var date = DateTime.ParseExact(value, "yyyy-MM-dd HH:mm:ss.fff", null);
+                    var date = DateTime.ParseExact(value, "yyyy-MM-dd HH:mm:ss.FFF", null);
                     return date;
                 }
             }

--- a/R6Sharp/R6Api.cs
+++ b/R6Sharp/R6Api.cs
@@ -218,7 +218,7 @@ namespace R6Sharp
         private async Task<T> GetData<T>(string endpoint, Guid uuid, KeyValuePair<string, string>[] queries)
         {
             var session = await _session.GetCurrentSessionAsync().ConfigureAwait(false);
-            var results = await ApiHelper.GetDataAsync(endpoint, uuid, queries, session).ConfigureAwait(false);
+            using var results = await ApiHelper.GetDataAsync(endpoint, uuid, queries, session).ConfigureAwait(false);
             var deserialised = await JsonSerializer.DeserializeAsync<T>(results).ConfigureAwait(false);
             return deserialised;
         }

--- a/R6Sharp/R6Api.cs
+++ b/R6Sharp/R6Api.cs
@@ -218,9 +218,16 @@ namespace R6Sharp
         private async Task<T> GetData<T>(string endpoint, Guid uuid, KeyValuePair<string, string>[] queries)
         {
             var session = await _session.GetCurrentSessionAsync().ConfigureAwait(false);
-            using var results = await ApiHelper.GetDataAsync(endpoint, uuid, queries, session).ConfigureAwait(false);
-            var deserialised = await JsonSerializer.DeserializeAsync<T>(results).ConfigureAwait(false);
-            return deserialised;
+            using var stream = await ApiHelper.GetDataAsync(endpoint, uuid, queries, session).ConfigureAwait(false);
+            if (stream != null)
+            {
+                var deserialised = await JsonSerializer.DeserializeAsync<T>(stream).ConfigureAwait(false);
+                return deserialised;
+            }
+            else
+            {
+                return default;
+            }
         }
     }
 }

--- a/R6Sharp/R6Api.cs
+++ b/R6Sharp/R6Api.cs
@@ -219,7 +219,7 @@ namespace R6Sharp
         {
             var session = await _session.GetCurrentSessionAsync().ConfigureAwait(false);
             var results = await ApiHelper.GetDataAsync(endpoint, uuid, queries, session).ConfigureAwait(false);
-            var deserialised = JsonSerializer.Deserialize<T>(results);
+            var deserialised = await JsonSerializer.DeserializeAsync<T>(results).ConfigureAwait(false);
             return deserialised;
         }
     }


### PR DESCRIPTION
JSON was previously deserialized synchronously while the requests themselves were asynchronous. In order to make the API wrapper completely asynchronous, the requests now return streams instead of strings so they can be deserialized asynchronously, handled by System.Text.Json.

On a minor note, the DateTime format sent by Ubisoft omitted trailing zeroes whereas the wrapper required trailing zeroes, causing the parsing to fail. This has been fixed by allowing trailing zeroes.

Fixes #7 